### PR TITLE
スクロールの幅、入力例、戻るボタン、コメント吹き出し　の修正

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -32,6 +32,16 @@
   animation: slideDown 0.5s ease-out;
 }
 
+/* コメントを吹き出しにする */
+.message-bubble {
+  background-color: #f1f1f1; /* 吹き出しの背景色 */
+  border-radius: 10px; /* 吹き出しの角を丸くする */
+  padding: 10px; /* 吹き出しの内側の余白 */
+  margin-left: 10px; /* アイコンとの隙間 */
+  position: relative; /* 吹き出しの位置を相対的にする */
+}
+
+
 /* ライブルーム一覧 */
 .list-group-flush {
   border-radius: 8px; // 角を8pxの半径で丸くする

--- a/app/controllers/live_rooms_controller.rb
+++ b/app/controllers/live_rooms_controller.rb
@@ -5,7 +5,7 @@ class LiveRoomsController < ApplicationController
   
   def show
     @live_room = LiveRoom.find(params[:id])
-    @messages = @live_room.messages.includes(:user)  # メッセージと関連するユーザーを事前にロード
+    @messages = @live_room.messages.includes(:user).order(created_at: :asc)  # メッセージと関連するユーザーを事前にロード
   end
   
   def create

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -85,8 +85,9 @@
       <!-- ここにヘッダーのコンテンツを追加 -->
       <nav>
         <ul>
-          <li><%= link_to "Home", root_path %></li>
           <li><%= link_to "ログアウト", destroy_user_session_path, method: :delete %></li>
+          <li><%= link_to "ホーム", root_path %></li>
+          <li><a href="javascript:history.back()">＜戻る</a></li>
           <!-- 他のページへのリンクを追加 -->
         </ul>
       </nav>

--- a/app/views/live_rooms/new.html.erb
+++ b/app/views/live_rooms/new.html.erb
@@ -1,9 +1,13 @@
-<div class="d-flex justify-content-center align-items-center" >
+<div class="d-flex justify-content-center align-items-center mt-5">
   <div class="container">
     <div class="row justify-content-center">
       <div class="col-md-6">
-        <div class="card bg-transparent border-0 text-white"> <!-- text-white を追加 -->
+        <div class="card bg-transparent border-0 text-white">
           <div class="card-title text-center bg-transparent border-0">
+            <!-- 入力例を追加 -->
+            <div class="bg-white text-dark p-2 mb-3 rounded">
+              例: ROCK IN JAPAN（2024/08/11）
+            </div>
           </div>
           <div class="card-body">
             <%= form_with model: LiveRoom.new, local: true, class: "mb-4" do |form| %>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -1,7 +1,7 @@
-<li class="list-group-item">
-  <div class="card">
+<li class="list-group-item bg-transparent border-0">
+  <div class="card bg-transparent border-0">
     <div class="card-body">
-      <div class="d-flex align-items-center mb-3">
+      <div class="d-flex align-items-start" style="margin-left: 300px;">
         <% if message.user.avatar.attached? %>
           <img class="rounded-circle img-thumbnail mr-3" src="<%= url_for(message.user.avatar) %>" style="width: 50px; height: 50px; object-fit: cover;">
         <% else %>
@@ -9,18 +9,22 @@
             <%= message.user.name[0].upcase %>
           </div>
         <% end %>
+        
+        <!-- 吹き出し -->
         <div>
-          <strong><%= message.user.name %></strong>
-          <div class="text-muted"><%= message.created_at.strftime("%Y-%m-%d %H:%M") %></div>
-        </div>
-      </div>
-      <div class="message">
-        <p class="card-text"><%= message.content %></p>
-        <% if message.image.attached? %>
-          <div class="mt-2">
-            <img class="img-fluid" src="<%= url_for(message.image) %>" style="width: 300px; height: auto;">
+          <div class="text-white">
+            <%= message.user.name %>
+            <span style="color: rgba(108, 117, 125, 10); margin-left: 0.5rem;"><%= message.created_at.strftime("%Y-%m-%d %H:%M") %></span> <!-- 透過グレーにする -->
           </div>
-        <% end %>
+          <div class="message-bubble mt-2">
+            <div class="card-text" style="color: black;"><%= message.content %></div>
+            <% if message.image.attached? %>
+              <div class="mt-2">
+                <img class="img-fluid" src="<%= url_for(message.image) %>" style="width: 300px; height: auto;">
+              </div>
+            <% end %>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/musics/index.html.erb
+++ b/app/views/musics/index.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-<div class="row justify-content-center">
+  <div class="row justify-content-center" style="max-height: 93vh; overflow-y: auto;">
     <div class="col-md-3 text-white text-center">
     <h4><%= @artist.name %></h4>
       <!-- @musicsが存在し、かつ中に音楽が含まれている場合の処理 -->


### PR DESCRIPTION
## 概要
- 曲の再生画面のスクロールの幅を広げる、ルームの入力例を記載、１前に戻るボタンの追加、チャットのコメントを吹き出しの様にする。

## 変更内容
- `app/views/messages/_message.html.erb`のメッセージのスタイルを変更しcssで見た目の変更
- `app/views/musics/index.html.erb`に`style="max-height: 93vh; overflow-y: auto;"`を追加し、スクロール幅の調整
- `app/views/layouts/application.html.erb`のヘッダーに`<a href="javascript:history.back()">＜戻る</a>`の追加
- `app/views/live_rooms/new.html.erb`に「例: ROCK IN JAPAN（2024/08/11）」と作成の記入例を表示

## 実装中のエラー
- エラーは特に出なかった

## その他
- ブラウザ上で全ての挙動の確認済み
- メッセージはログイン中のユーザーとその他のユーザーで表示する方向を右と左に分けたいが、その実装は今後取り入れる
（`devise`と`current_user`の関係性がうまくいかず、`current_user`を入れるとWebSocketが機能しなくなってしまったため今回は実装から外した。改めて実装方法を調査し導入する）







