### PR TITLE
チャットのメッセージを左右に分ける

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,4 +1,8 @@
-module ApplicationCable
-  class Connection < ActionCable::Connection::Base
+class ApplicationController < ActionController::Base
+  def self.render_with_signed_in_user(user, *args)
+    ActionController::Renderer::RACK_KEY_TRANSLATION['warden'] ||= 'warden'
+    proxy = Warden::Proxy.new({}, Warden::Manager.new({})).tap { |i| i.set_user(user, scope: :user) }
+    renderer = self.renderer.new('warden' => proxy)
+    renderer.render(*args)
   end
 end

--- a/app/channels/live_room_channel.rb
+++ b/app/channels/live_room_channel.rb
@@ -16,8 +16,13 @@ class LiveRoomChannel < ApplicationCable::Channel
       message.image.attach(io: StringIO.new(decoded_image), filename: 'uploaded_image.png')
     end
 
+    # メッセージの保存、サインインしているユーザーのコンテキストでビューをレンダリング
     message.save!
-      template = ApplicationController.renderer.render(partial: 'messages/message', locals: { message: message })
-      LiveRoomChannel.broadcast_to(live_room, template)
+    template = ApplicationController.render_with_signed_in_user(
+      User.find(data['user_id']),
+      partial: 'messages/message',
+      locals: { message: message }
+    )
+    LiveRoomChannel.broadcast_to(live_room, template)
   end
 end

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -1,7 +1,7 @@
 <li class="list-group-item bg-transparent border-0">
   <div class="card bg-transparent border-0">
     <div class="card-body">
-      <div class="d-flex align-items-start" style="margin-left: 300px;">
+      <div class="d-flex align-items-start <%= message.user == current_user ? 'justify-content-end' : 'justify-content-start' %>">
         <% if message.user.avatar.attached? %>
           <img class="rounded-circle img-thumbnail mr-3" src="<%= url_for(message.user.avatar) %>" style="width: 50px; height: 50px; object-fit: cover;">
         <% else %>


### PR DESCRIPTION
## 概要
- チャット欄のメッセージをログイン中のユーザーを右、その他のユーザーを左にする。

## 変更内容
① `app/views/messages/_message.html.erb`に`message.user == current_user ?`で現在のユーザーかの確認を追記

②`app/channels/application_cable/connection.rb`にActionCableでも、特定のユーザーがサインインしている状態でビューを正しくレンダリングするように記載。
③ `app/channels/live_room_channel.rb`の`template`を`render_with_signed_in_user`をレンダリングできる様に記載。

## 実装中のエラー
①の記載をした際にコメントを分けることはできるがWebSocketが機能しなくなる（更新しないとコメントが表示されない）

## エラーの解消
②、③の記載で`current_userとdevise`との関係性の問題を解消。
エラー内容
```
Devise could not find the `Warden::Proxy` instance on your request environment
```

## その他
- ブラウザ上で全ての挙動の確認済み







