### PR TITLE
記載ファイルの誤りを修正

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,8 +1,4 @@
-class ApplicationController < ActionController::Base
-  def self.render_with_signed_in_user(user, *args)
-    ActionController::Renderer::RACK_KEY_TRANSLATION['warden'] ||= 'warden'
-    proxy = Warden::Proxy.new({}, Warden::Manager.new({})).tap { |i| i.set_user(user, scope: :user) }
-    renderer = self.renderer.new('warden' => proxy)
-    renderer.render(*args)
+module ApplicationCable
+  class Connection < ActionCable::Connection::Base
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,16 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
-  # ここから追加します
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name]) # 新規登録時(sign_up時)にnameのパラメーターを追加で許可する
   end
-  # ここまで追加します
+
+  def self.render_with_signed_in_user(user, *args)
+    ActionController::Renderer::RACK_KEY_TRANSLATION['warden'] ||= 'warden'
+    proxy = Warden::Proxy.new({}, Warden::Manager.new({})).tap { |i| i.set_user(user, scope: :user) }
+    renderer = self.renderer.new('warden' => proxy)
+    renderer.render(*args)
+  end
 end


### PR DESCRIPTION
## 概要
- `app/controllers/application_controller.rb`に記載するものを別のファイルに誤って記載していたため修正

## 変更内容
① `app/channels/application_cable/connection.rb`に誤って記載したためそちらは削除し`app/controllers/application_controller.rb`に再度記載
記載内容
```
 def self.render_with_signed_in_user(user, *args)
    ActionController::Renderer::RACK_KEY_TRANSLATION['warden'] ||= 'warden'
    proxy = Warden::Proxy.new({}, Warden::Manager.new({})).tap { |i| i.set_user(user, scope: :user) }
    renderer = self.renderer.new('warden' => proxy)
    renderer.render(*args)
  end
```

## 実装中のエラー
- 無し


## その他
- ブラウザ上で全ての挙動の確認済み