### PR TITLE
戻るボタンの遷移先を修正

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -154,14 +154,14 @@
           <% if controller_name == 'musics' && action_name == 'index' %>
             <% live_event = LiveEvent.find(params[:live_event_id]) if params[:live_event_id].present? %>
             <li class="nav-item">
-              <%= link_to '＜戻る', live_events_path(live_event), class: 'nav-link text-white', style: 'font-size: 18px;' %>
+              <%= link_to '＜戻る', live_event_path(live_event), class: 'nav-link text-white', style: 'font-size: 18px;' %>
             </li>
           <% end %>
           <% if controller_name == 'musics' && action_name == 'show' %>
-            <% if params[:artist_id].present? %>
-              <li class="nav-item">
-                <%= link_to '＜戻る', musics_path(artist_id: params[:artist_id]), class: 'nav-link text-white', style: 'font-size: 18px;' %>
-              </li>
+          <% if params[:artist_id].present? %>
+            <li class="nav-item">
+              <%= link_to '＜戻る', musics_path(artist_id: params[:artist_id], live_event_id: params[:live_event_id]), class: 'nav-link text-white', style: 'font-size: 18px;' %>
+            </li>
             <% end %>
           <% end %>
         </ul>

--- a/app/views/musics/index.html.erb
+++ b/app/views/musics/index.html.erb
@@ -13,7 +13,7 @@
             <div class="list-group-item d-flex justify-content-between align-items-center mb-3 shadow-sm rounded" style="background-color: rgba(248, 249, 250, 0.4);">
               <div class="d-flex align-items-center flex-grow-1">
                 <!-- 曲の番号と名前全体をリンクにします -->
-                <%= link_to artist_music_path(@artist, music[:id]), class: 'text-decoration-none text-dark d-flex align-items-center w-100' do %>
+                <%= link_to artist_music_path(@artist, music[:id], live_event_id: params[:live_event_id]), class: 'text-decoration-none text-dark d-flex align-items-center w-100' do %>
                   <h5 class="mb-0 me-3 flex-grow-1">
                     <%= "#{index + 1}. #{music[:name]}" %>
                   </h5>


### PR DESCRIPTION
## 概要
- 戻るボタンの遷移先に間違いがあったため修正しました。

## 変更内容
①  `ライブイベント選択ページ ` ⇨  `参加アーティスト選択ページ`  ⇨  `曲の選択ページ`の画面遷移でそれぞれのページで次のページに任意のidを渡す様に修正。
② `app/views/musics/index.html.erb`で`live_event_id`を渡せていなかったので、渡す様に記載。
    `app/views/layouts/application.html.erb`で曲の選択ページに遷移するときに`live_event_id`を渡せていなかったので、渡す様に記載。

## 実装中のエラー
`参加アーティスト選択ページ`  ⇨  `曲の選択ページ`に移動したときURLに`live_event_id`が表示されていないことに気づかず
`live_event_idが見つかりません`のエラーにハマってしまった。

## エラーの解消
②の実装により解消

## その他
- ブラウザ上で全ての挙動の確認済み